### PR TITLE
Flask: Adding missing Flask-Testing dependency

### DIFF
--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -2,6 +2,7 @@ Flask==0.9
 Flask-Login==0.1.3
 Flask-Mail==0.7.6
 Flask-SQLAlchemy==0.16
+Flask-Testing==0.4.2
 Flask-WTF==0.8.3
 Jinja2==2.6
 SQLAlchemy==0.8.0


### PR DESCRIPTION
Following the guidelines in [README.rst](flask/README.rst), there seems to be a missing dependency in the requirements.txt file, which causes the tests to fail:

``` python
$ python tests.py 
Traceback (most recent call last):
  File "tests.py", line 9, in <module>
    from flask.ext.testing import TestCase
  File "/home/benno/.virtualenvs/notejam/local/lib/python2.7/site-packages/flask/exthook.py", line 86, in load_module
    raise ImportError('No module named %s' % fullname)
ImportError: No module named flask.ext.testing
```

Adding `Flask-Testing` as a dependency solved this.
