### PR TITLE
Django: Replace deprecated assertEquals with assertEqual

### DIFF
--- a/django/notejam/notes/tests.py
+++ b/django/notejam/notes/tests.py
@@ -17,11 +17,11 @@ class NoteTest(TestCase):
     def test_create_success(self):
         self.client.post(
             reverse('create_note'), {'name': 'pad', 'text': 'pad text'})
-        self.assertEquals(1, Note.objects.count())
+        self.assertEqual(1, Note.objects.count())
 
     def test_create_fail_required_fields(self):
         response = self.client.post(reverse('create_note'), {})
-        self.assertEquals(
+        self.assertEqual(
             set(['name', 'text']), set(response.context['form'].errors.keys()))
 
     def test_edit_success(self):
@@ -35,7 +35,7 @@ class NoteTest(TestCase):
         response = self.client.post(
             reverse('edit_note', args=(note.id,)), note_data)
         self.assertRedirects(response, reverse('home'))
-        self.assertEquals(note_data['name'], Note.objects.get(id=note.id).name)
+        self.assertEqual(note_data['name'], Note.objects.get(id=note.id).name)
 
     def test_another_user_cant_edit(self):
         user_data = {
@@ -53,7 +53,7 @@ class NoteTest(TestCase):
         client = Client()
         client.login(**user_data)
         response = client.post(reverse('edit_note', args=(note.id,)), {})
-        self.assertEquals(404, response.status_code)
+        self.assertEqual(404, response.status_code)
 
     def test_view_success(self):
         note_data = {
@@ -62,7 +62,7 @@ class NoteTest(TestCase):
         }
         note = Note.objects.create(user=self.user, **note_data)
         response = self.client.get(reverse('view_note', args=(note.id,)), {})
-        self.assertEquals(note, response.context['note'])
+        self.assertEqual(note, response.context['note'])
 
     def test_another_user_cant_view(self):
         user_data = {
@@ -80,7 +80,7 @@ class NoteTest(TestCase):
         client = Client()
         client.login(**user_data)
         response = client.get(reverse('view_note', args=(note.id,)), {})
-        self.assertEquals(404, response.status_code)
+        self.assertEqual(404, response.status_code)
 
     def test_delete_success(self):
         note_data = {
@@ -89,7 +89,7 @@ class NoteTest(TestCase):
         }
         note = Note.objects.create(user=self.user, **note_data)
         self.client.post(reverse('delete_note', args=(note.id,)), {})
-        self.assertEquals(0, Note.objects.count())
+        self.assertEqual(0, Note.objects.count())
 
     def test_another_user_cant_delete(self):
         user_data = {
@@ -107,4 +107,4 @@ class NoteTest(TestCase):
         client = Client()
         client.login(**user_data)
         response = client.get(reverse('view_note', args=(note.id,)), {})
-        self.assertEquals(404, response.status_code)
+        self.assertEqual(404, response.status_code)

--- a/django/notejam/pads/tests.py
+++ b/django/notejam/pads/tests.py
@@ -22,7 +22,7 @@ class PadTest(TestCase):
 
     def test_create_success(self):
         self.client.post(reverse('create_pad'), {'name': 'pad'})
-        self.assertEquals(1, Pad.objects.count())
+        self.assertEqual(1, Pad.objects.count())
 
     def test_create_fail_required_name(self):
         response = self.client.post(reverse('create_pad'), {})
@@ -33,7 +33,7 @@ class PadTest(TestCase):
         data = {'name': 'new name'}
         response = self.client.post(reverse('edit_pad', args=(id,)), data)
         self.assertRedirects(response, reverse('view_pad_notes', args=(id,)))
-        self.assertEquals(data['name'], Pad.objects.get(id=id).name)
+        self.assertEqual(data['name'], Pad.objects.get(id=id).name)
 
     def test_another_user_cant_edit_pad(self):
         user_data = {
@@ -46,4 +46,4 @@ class PadTest(TestCase):
         client.login(**user_data)
         id = self._create_pads(['pad'])[0]
         response = client.post(reverse('edit_pad', args=(id,)), {})
-        self.assertEquals(404, response.status_code)
+        self.assertEqual(404, response.status_code)


### PR DESCRIPTION
The `assertEquals` function in `unittest` has been deprecated and the recommended function is now `assertEqual`

See https://docs.python.org/3.3/library/unittest.html#deprecated-aliases