### PR TITLE
Flask - fix password size in model

### DIFF
--- a/flask/notejam/models.py
+++ b/flask/notejam/models.py
@@ -10,7 +10,7 @@ from notejam import db
 class User(db.Model, UserMixin):
     id = db.Column(db.Integer, primary_key=True)
     email = db.Column(db.String(120), unique=True)
-    password = db.Column(db.String(36))
+    password = db.Column(db.String(43))
 
     @staticmethod
     def authenticate(email, password):


### PR DESCRIPTION
The generate_password_hash produces a 43 chars long string