### PR TITLE
Flask: Increase password field size

### DIFF
--- a/flask/notejam/models.py
+++ b/flask/notejam/models.py
@@ -10,7 +10,7 @@ from notejam import db
 class User(db.Model, UserMixin):
     id = db.Column(db.Integer, primary_key=True)
     email = db.Column(db.String(120), unique=True)
-    password = db.Column(db.String(36))
+    password = db.Column(db.String(100))
 
     @staticmethod
     def authenticate(email, password):


### PR DESCRIPTION
The password field was tested up to 70 chars, so a precaution of 100 chars is selected