### PR TITLE
Fix fatal error

### DIFF
--- a/yii/README.rst
+++ b/yii/README.rst
@@ -39,7 +39,7 @@ Install dependencies
 .. code-block:: bash
 
     $ cd YOUR_PROJECT_DIR/yii/notejam
-    $ php composer.phar install
+    $ php composer.phar update
 
 Create database schema
 


### PR DESCRIPTION
Problem 1
- Installation request for phpunit/phpunit 4.8.x-dev -> satisfiable by phpunit/phpunit[4.8.x-dev].
- phpunit/phpunit 4.8.x-dev requires phpunit/phpunit-mock-objects ~2.3 -> no matching package found.
Problem 2
- phpunit/phpunit 4.8.x-dev requires phpunit/phpunit-mock-objects ~2.3 -> no matching package found.
- codeception/codeception dev-master requires phpunit/phpunit ~4.8.0 -> satisfiable by phpunit/phpunit[4.8.x-dev].
- Installation request for codeception/codeception dev-master -> satisfiable by codeception/codeception[dev-master].