### PR TITLE
Rubyonrails: updated bcrypt dependency

### DIFF
--- a/rubyonrails/notejam/Gemfile
+++ b/rubyonrails/notejam/Gemfile
@@ -33,7 +33,7 @@ group :doc do
 end
 
 # Use ActiveModel has_secure_password
-gem 'bcrypt-ruby', '~> 3.1.2'
+gem 'bcrypt', '~> 3.1.2'
 
 # Use unicorn as the app server
 # gem 'unicorn'


### PR DESCRIPTION
The bcrypt-ruby gem has been renamed to just bcrypt. This change removes the deprecation warning that shows when installing bcrypt-ruby.