### PR TITLE
Configuration changes

### DIFF
--- a/flask/notejam/config.py
+++ b/flask/notejam/config.py
@@ -1,23 +1,21 @@
 import os
+
+
 basedir = os.path.abspath(os.path.dirname(__file__))
 
 class Config(object):
-    DEBUG = False
-    TESTING = False
     SECRET_KEY = 'notejam-flask-secret-key'
     CSRF_ENABLED = True
-    CSRF_SESSION_KEY = 'notejam-flask-secret-key'
     SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(basedir, 'notejam.db')
-
-
-class ProductionConfig(Config):
-    DEBUG = False
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 
 class DevelopmentConfig(Config):
-    DEVELOPMENT = True
     DEBUG = True
+    CSRF_ENABLED = False
 
 
-class TestingConfig(Config):
+class TestingConfig(DevelopmentConfig):
     TESTING = True
+    PRESERVE_CONTEXT_ON_EXCEPTION = False
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'

--- a/flask/tests.py
+++ b/flask/tests.py
@@ -22,15 +22,10 @@ class NotejamBaseTestCase(TestCase):
     def tearDown(self):
         db.session.remove()
         db.drop_all()
-        os.close(self.fd)
-        os.unlink(self.db)
 
     def create_app(self):
         self.fd, self.db = tempfile.mkstemp()
         test_app = app
-        test_app.config['SQLALCHEMY_DATABASE_URI'] = "sqlite:///" + self.db
-        test_app.config['TESTING'] = True
-        test_app.config['CSRF_ENABLED'] = False
         return test_app
 
     def create_user(self, **kwargs):


### PR DESCRIPTION
- use sqlite:///:memory: in TestConfig
- Remove redundant configuration from tests.py